### PR TITLE
Add tt -> t-t and one fünff rule

### DIFF
--- a/selnolig-german-patterns.sty
+++ b/selnolig-german-patterns.sty
@@ -467,6 +467,8 @@
   % fünffarbig fünffingrig fünfflügelig 
   % Fünfflach fünfflammig fünffleckige  
 
+\nolig{fünff[ale]}{fünf|f}
+
 \nolig{wurff[aäeiloöruü]}{wurf|f}
   % Auswurffach Einwurffehler 
   % Hammerwurffinale
@@ -1957,3 +1959,11 @@
   % ligatures into 'ff' and 'fl' parts.
   % Examples: Sauerstoffflasche Stofffleck
   %           Schlifffläche Kunststoffflügel
+
+% 12. tt -> t-t
+% ---------------
+\nolig{Herbstt[aruöe]}{Herbst|t}
+  % Herbst-tagung
+\nolig{Mitt[iruä]}{Mit|t}
+\nolig{Textt[eiru]}{Text|t}
+\nolig{Hauptt[eiru]}{Haupt|t}


### PR DESCRIPTION
I got some patterns from [Herbert Voß](https://de.wikipedia.org/wiki/Herbert_Vo%C3%9F). With the "tt -> t-t" rules, I am sure. With the rule `\nolig{fünff[ale]}{fünf|f}` I am not sure whether it is already covered by line 466.