### PR TITLE
Debug table

### DIFF
--- a/selnolig.lua
+++ b/selnolig.lua
@@ -23,7 +23,13 @@ selnolig.module = {
    license      = "LPPL 1.3 or later"
 }
 
-debug=false -- default: don't output detailed information
+local debug=false -- default: don't output detailed information
+
+-- Preliminary functions to fix the worst issue.
+-- TODO: wrap the whole module in one table and return *that*
+-- to have a single global variable exposed.
+function selnolig_debug_on() debug=true end
+function selnolig_debug_off() debug=false end
 
 -- Define variables corresponding to various text nodes;
 -- cf. sections 8.1.2 and 8.1.4 of LuaTeX reference guide

--- a/selnolig.lua
+++ b/selnolig.lua
@@ -12,8 +12,7 @@
 -- later. (http://www.latex-project.org/lppl.txt).
 -- It has the status "maintained".
 
-selnolig = { }
-selnolig.module = {
+local err, warn, info, log = luatexbase.provides_module({
    name         = "selnolig",
    version      = "0.256",
    date         = "2015/10/26",
@@ -21,15 +20,14 @@ selnolig.module = {
    author       = "Mico Loretan",
    copyright    = "Mico Loretan",
    license      = "LPPL 1.3 or later"
-}
+})
+selnolig = { }
 
 local debug=false -- default: don't output detailed information
 
--- Preliminary functions to fix the worst issue.
--- TODO: wrap the whole module in one table and return *that*
--- to have a single global variable exposed.
-function selnolig_debug_on() debug=true end
-function selnolig_debug_off() debug=false end
+function selnolig.activate_debug(status)
+    debug=status
+end
 
 -- Define variables corresponding to various text nodes;
 -- cf. sections 8.1.2 and 8.1.4 of LuaTeX reference guide
@@ -49,7 +47,7 @@ local identifier = 123456  -- any unique identifier
 local noliga={}
 local keepliga={}          -- String -> Boolean
 
-function debug_info(s)
+local function debug_info(s)
   if debug then
     texio.write_nl(s)
   end
@@ -88,7 +86,7 @@ local unicode_find = function(s, pattern, position)
   end
 end
 
-function process_ligatures(nodes,tail)
+local function process_ligatures(nodes,tail)
   if not suppression_on then
     return -- suppression disabled
   end
@@ -179,15 +177,15 @@ function process_ligatures(nodes,tail)
   end
 end -- end of function process_ligatures(nodes,tail)
 
-function suppress_liga(s,t)
+function selnolig.suppress_liga(s,t)
   noliga[s] = t
 end
 
-function always_keep_liga(s)
+function selnolig.always_keep_liga(s)
   keepliga[s] = true
 end
 
-function enable_suppression(val)
+function selnolig.enable_suppression(val)
   suppression_on = val
   if val then
     debug_info("Turning ligature suppression back on")
@@ -196,12 +194,14 @@ function enable_suppression(val)
   end
 end
 
-function enableselnolig()
+function selnolig.enableselnolig()
   luatexbase.add_to_callback( "ligaturing",
     process_ligatures, "Suppress ligatures selectively", 1 )
 end
 
-function disableselnolig()
+function selnolig.disableselnolig()
   luatexbase.remove_from_callback( "ligaturing",
     "Suppress ligatures selectively" )
 end
+
+return selnolig

--- a/selnolig.lua
+++ b/selnolig.lua
@@ -1,14 +1,14 @@
 -- Lua code for the selnolig package.
--- To be loaded with an instruction such as 
+-- To be loaded with an instruction such as
 --    \directlua{  require("selnolig.lua")  }
 -- from a (Lua)LaTeX .sty file.
 --
 -- Author: Mico Loretan (loretan dot mico at gmail dot com)
---    (with crucial contributions from Taco Hoekwater, 
+--    (with crucial contributions from Taco Hoekwater,
 --    Patrick Gundlach, and Steffen Hildebrandt)
 --
--- The entire selnolig package is placed under the terms 
--- of the LaTeX Project Public License, version 1.3 or 
+-- The entire selnolig package is placed under the terms
+-- of the LaTeX Project Public License, version 1.3 or
 -- later. (http://www.latex-project.org/lppl.txt).
 -- It has the status "maintained".
 
@@ -65,8 +65,8 @@ local prefix_length = function(word, byte)
   return unicode.utf8.len( string.sub(word,0,byte) )
 end
 
-  -- Problem: string.find and unicode.utf8.find return 
-  -- the byte-position at which the pattern is found 
+  -- Problem: string.find and unicode.utf8.find return
+  -- the byte-position at which the pattern is found
   -- instead of the character-position. Fix this by
   -- providing a dedicated string search function.
 
@@ -92,7 +92,7 @@ function process_ligatures(nodes,tail)
   if not suppression_on then
     return -- suppression disabled
   end
-  
+
   local s={}
   local current_node=nodes
   local build_liga_table =  function(strlen,t)
@@ -139,9 +139,9 @@ function process_ligatures(nodes,tail)
     if t.id==glyph then
       s[#s+1]=unicode.utf8.char(t.char)
     end
-    if ( t.id==glue or t.next==nil or t.id==kern or t.id==rule ) then 
+    if ( t.id==glue or t.next==nil or t.id==kern or t.id==rule ) then
       local f=string.gsub(table.concat(s,""),"[\\?!,\\.]+","")
-      local throwliga={} 
+      local throwliga={}
       for k,v in pairs (noliga) do
         local count=1
         local match = string.find(f,k)
@@ -197,11 +197,11 @@ function enable_suppression(val)
 end
 
 function enableselnolig()
-  luatexbase.add_to_callback( "ligaturing", 
+  luatexbase.add_to_callback( "ligaturing",
     process_ligatures, "Suppress ligatures selectively", 1 )
 end
 
 function disableselnolig()
-  luatexbase.remove_from_callback( "ligaturing", 
+  luatexbase.remove_from_callback( "ligaturing",
     "Suppress ligatures selectively" )
 end

--- a/selnolig.sty
+++ b/selnolig.sty
@@ -157,15 +157,15 @@
 
 \ifluatex
   % Load the lua code contained in 'selnolig.lua'.
-  \directlua{  require("selnolig.lua")  }
+  \directlua{ selnolig = require("selnolig.lua")  }
 
   % Commands to switch selnolig's routines on and off
   \newcommand\selnoligon{%
-    \directlua{ enableselnolig() }%
+    \directlua{ selnolig.enableselnolig() }%
   }
 
   \newcommand\selnoligoff{%
-    \directlua{ disableselnolig() }%
+    \directlua{ selnolig.disableselnolig() }%
   }
 
   % By default, selnolig's macros are switched on
@@ -178,17 +178,17 @@
   %    'selnolig.lua') is 'false'. To turn off logging
   % of selnolig's activity, use the command \debugoff.
   \newcommand\debugon{%
-     \directlua{ selnolig_debug_on }
+     \directlua{ selnolig.activate_debug(true) }
   }
   \newcommand\debugoff{%
-     \directlua{ selnolig_debug_off }
+     \directlua{ selnolig.activate_debug(false) }
   }
 
 
   % The first main user macro is called '\nolig':
   \newcommand\nolig[2]{
      \directlua{
-        suppress_liga( "\luatexluaescapestring{#1}",
+        selnolig.suppress_liga( "\luatexluaescapestring{#1}",
                        "\luatexluaescapestring{#2}" )
      }
   }
@@ -197,16 +197,16 @@
   % rules set by \nolig instructions:
   \newcommand\keeplig[1]{
      \directlua{
-        always_keep_liga( "\luatexluaescapestring{#1}" )
+        selnolig.always_keep_liga( "\luatexluaescapestring{#1}" )
      }
   }
 
   % A third user macro turns ligature suppression off
   % temporarily:
   \newcommand\uselig[1]{%
-    \directlua{ enable_suppression(false) }%
+    \directlua{ selnolig.enable_suppression(false) }%
     \mbox{#1}%
-    \directlua{ enable_suppression(true) }%
+    \directlua{ selnolig.enable_suppression(true) }%
   }
 
   % A fourth user macro: '\breaklig'. This is

--- a/selnolig.sty
+++ b/selnolig.sty
@@ -178,10 +178,10 @@
   %    'selnolig.lua') is 'false'. To turn off logging 
   % of selnolig's activity, use the command \debugoff.
   \newcommand\debugon{%
-     \directlua{ debug=true }
+     \directlua{ selnolig_debug_on }
   }
-  \newcommand\debugoff{% 
-     \directlua{ debug=false }
+  \newcommand\debugoff{%
+     \directlua{ selnolig_debug_off }
   }
 
 

--- a/selnolig.sty
+++ b/selnolig.sty
@@ -16,10 +16,10 @@
 \def\selnoligpackageversion{0.302}
 \def\selnoligpackagedate{2015/10/26}
 
-% Announce who we are. 
+% Announce who we are.
 
-\typeout{=== Package \selnoligpackagename, 
-             Version \selnoligpackageversion, 
+\typeout{=== Package \selnoligpackagename,
+             Version \selnoligpackageversion,
              Date    \selnoligpackagedate\space ===}
 \ProvidesPackage{selnolig}[\selnoligpackagedate]
 
@@ -43,11 +43,11 @@
 
 % If the 'fontspec' package isn't loaded by the time
 % the '\begin{document}' directive is encoutered, issue
-% an error message and exit. 
+% an error message and exit.
 
 \AtBeginDocument{%
 \ifluatex
-  \@ifpackageloaded{fontspec}{}{%  
+  \@ifpackageloaded{fontspec}{}{%
   \PackageError{selnolig}{%
      ========================================== \MessageBreak
           Error Alert      Error Alert          \MessageBreak
@@ -65,7 +65,7 @@
 
 % The main language options are 'english' and 'german'.
 % We provide the option 'otherlang' option just in case
-% a user wants to provide ligature suppression patterns 
+% a user wants to provide ligature suppression patterns
 % for languages other than English and German.
 
 \newif\if@english\@englishfalse
@@ -104,25 +104,25 @@
 %
 % Two options to augment the "basic" setting:
 % - broadf   More non-ligation rules for f-ligatures
-% - hdlig    Additional ligature suppression rules for 
-%            'historic' and/or 'discretionary' ligatures, 
-%            e.g., ct, sp, st, sk, th, as, is, us, fr, 
+% - hdlig    Additional ligature suppression rules for
+%            'historic' and/or 'discretionary' ligatures,
+%            e.g., ct, sp, st, sk, th, as, is, us, fr,
 %            ll, et, at, and ta
 
 \newif\if@broadfset\@broadfsetfalse
 \DeclareOption{broadf}{\@broadfsettrue}
 
-\newif\if@hdligset\@hdligsetfalse 
+\newif\if@hdligset\@hdligsetfalse
 \DeclareOption{hdlig}{\@hdligsettrue}
 
-% The 'basic' option automatically sets the preceding 
-% Booleans to 'false'. 
+% The 'basic' option automatically sets the preceding
+% Booleans to 'false'.
 
 \DeclareOption{basic}{\@broadfsetfalse\@hdligsetfalse}
 
 
-% The package also provides hyphenation exception 
-% patterns for English and German language words. 
+% The package also provides hyphenation exception
+% patterns for English and German language words.
 % Loading these patterns is enabled by default. This
 % can be disabled by providing the option
 % 'noadditionalhyphenationpatterns'.
@@ -139,8 +139,8 @@
 \DeclareOption{noftligs}{\@noftligstrue}
 
 
-% Finally, an option to set most language-related 
-% Boolean variables (other than '@addlhyph') to 
+% Finally, an option to set most language-related
+% Boolean variables (other than '@addlhyph') to
 % 'true' simultaneously.
 
 \DeclareOption{all}{%
@@ -155,10 +155,10 @@
 % Part 2: Load the lua code and set up the user macros
 % ----------------------------------------------------
 
-\ifluatex 
+\ifluatex
   % Load the lua code contained in 'selnolig.lua'.
   \directlua{  require("selnolig.lua")  }
-  
+
   % Commands to switch selnolig's routines on and off
   \newcommand\selnoligon{%
     \directlua{ enableselnolig() }%
@@ -167,15 +167,15 @@
   \newcommand\selnoligoff{%
     \directlua{ disableselnolig() }%
   }
-  
+
   % By default, selnolig's macros are switched on
   \selnoligon
-  
-  
-  % Recording operations of selnolig package to the log 
-  % file is enabled via the '\debugon' command. 
-  % Note: the default value of 'debug' (set in 
-  %    'selnolig.lua') is 'false'. To turn off logging 
+
+
+  % Recording operations of selnolig package to the log
+  % file is enabled via the '\debugon' command.
+  % Note: the default value of 'debug' (set in
+  %    'selnolig.lua') is 'false'. To turn off logging
   % of selnolig's activity, use the command \debugoff.
   \newcommand\debugon{%
      \directlua{ selnolig_debug_on }
@@ -192,7 +192,7 @@
                        "\luatexluaescapestring{#2}" )
      }
   }
-  
+
   % A second user macro allows global overriding of
   % rules set by \nolig instructions:
   \newcommand\keeplig[1]{
@@ -209,8 +209,8 @@
     \directlua{ enable_suppression(true) }%
   }
 
-  % A fourth user macro: '\breaklig'. This is  
-  % hopefully easier to remember than having to 
+  % A fourth user macro: '\breaklig'. This is
+  % hopefully easier to remember than having to
   % type "\-\hspace{0pt}".
 
   \newcommand{\breaklig}{\-{\hspace{0pt}}}
@@ -224,7 +224,7 @@
   \newcommand{\nolig}[2]{}
   \newcommand{\keeplig}[1]{}
   \newcommand{\uselig}[1]{\mbox{#1}}
-  \newcommand{\breaklig}{\-{\hspace{0pt}}} 
+  \newcommand{\breaklig}{\-{\hspace{0pt}}}
   \let\selnoligon\relax
   \let\selnoligoff\relax
   \let\debugon\relax


### PR DESCRIPTION
Writing a Lua-based package I suddenly stumbled over a seemingly unexplicable error message `attempt to index global 'debug' (a boolean value).` After some poking I managed to track this down to the use of `selnolig` in one of my documents, and further investigation turned up this line to be the culprit: https://github.com/micoloretan/selnolig/blob/master/selnolig.lua#L26

Using global variables is always risky, doing so without need should be avoided, and *overwriting a [standard library](https://www.lua.org/manual/5.1/manual.html#5.9)* is a cardinal sin ...

This Pull Request fixes the “deadly“ issue and improves the module by wrapping everything in *one single* global variable with the unique name `selnolig`. If it were my own package I would apply some more changes but I have deliberately not changed anything beyond the necessary.

It would be nice if you could merge this and release an update to CTAN as soon as possible because I have to document the incompatibility in my soon-to-be-released package [luaformatters](https://github.com/lualatex-tools/luaformatters). If you release an update right now then it would be guaranteed that the packages in CTAN and Tex Live will work together.
